### PR TITLE
Update management.properties

### DIFF
--- a/etc/cas/config/management.properties
+++ b/etc/cas/config/management.properties
@@ -1,13 +1,13 @@
 # CAS server that management app will authenticate with
 # This server will authenticate for any app (service) and you can login as casuser/Mellon 
-cas.server.name: https://jasigcas.herokuapp.com
-cas.server.prefix: https://jasigcas.herokuapp.com/cas
+server.name: https://jasigcas.herokuapp.com
+server.prefix: https://jasigcas.herokuapp.com/cas
 
-cas.mgmt.adminRoles[0]=ROLE_ADMIN
-cas.mgmt.userPropertiesFile=file:/etc/cas/config/users.properties
+mgmt.adminRoles[0]=ROLE_ADMIN
+mgmt.userPropertiesFile=file:/etc/cas/config/users.properties
 
 # Update this URL to point at server running this management app
-cas.mgmt.serverName=https://mmoayyed.unicon.net:8443
+mgmt.serverName=https://mmoayyed.unicon.net:8443
 
 server.context-path=/cas-management
 server.port=8443


### PR DESCRIPTION
The cas. prefix is not used in 5.3 and causes errors like, "Cannot access indexed value in property referenced in indexed property path 'mgmt[userPropertiesFile]'"