### PR TITLE
Update management.properties

### DIFF
--- a/etc/cas/config/management.properties
+++ b/etc/cas/config/management.properties
@@ -1,7 +1,7 @@
 # CAS server that management app will authenticate with
-# This server will authenticate for any app (service) and you can login as casuser/Mellon 
-cas.server.name: https://jasigcas.herokuapp.com
-cas.server.prefix: https://jasigcas.herokuapp.com/cas
+# This server will authenticate for any app (service) and you can login as casuser/Mellon
+cas.server.name=https://casserver.herokuapp.com
+cas.server.prefix=${cas.server.name}/cas
 
 mgmt.adminRoles[0]=ROLE_ADMIN
 mgmt.userPropertiesFile=file:/etc/cas/config/users.properties

--- a/etc/cas/config/management.properties
+++ b/etc/cas/config/management.properties
@@ -3,11 +3,11 @@
 cas.server.name: https://jasigcas.herokuapp.com
 cas.server.prefix: https://jasigcas.herokuapp.com/cas
 
-cas.mgmt.adminRoles[0]=ROLE_ADMIN
-cas.mgmt.userPropertiesFile=file:/etc/cas/config/users.properties
+mgmt.adminRoles[0]=ROLE_ADMIN
+mgmt.userPropertiesFile=file:/etc/cas/config/users.properties
 
 # Update this URL to point at server running this management app
-cas.mgmt.serverName=https://mmoayyed.unicon.net:8443
+mgmt.serverName=https://mmoayyed.unicon.net:8443
 
 server.context-path=/cas-management
 server.port=8443


### PR DESCRIPTION
The cas prefix is not used for mgmt properties in 5.3. It will cause errors like, "Invalid property 'mgmt[serverName]'